### PR TITLE
Add Assertible to SaSS tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [Apiary](https://apiary.io/) - Collaborative design, instant API mock, generated documentation, integrated code samples, debugging and automated testing.
 * [Amazon API Gateway](https://aws.amazon.com/api-gateway/) - Amazon API Gateway is a fully managed service that makes it easy for developers to create, publish, maintain, monitor, and secure APIs at any scale.
 * [Apigee](https://apigee.com) - Apigee is the leading provider of API technology and services for enterprises and developers.
+* [Assertible](https://assertible.com) - Continuously test and monitor your APIs after deployments and across environments.
 
 
 ## Miscellaneous


### PR DESCRIPTION
This adds [Assertible](https://assertible.com) to the SaSS tools section. I believe I got all of the formatting and punctuation correct per the contributing guidelines, but let me know if you need any changes. Thanks for putting this together!

- Cody Reichert