### PR TITLE
Add http-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [jq](https://github.com/stedolan/jq) - Command line JSON processor, to use in combination with a command-line HTTP client like cURL.
 * [HttpMaster](http://www.httpmaster.net) - GUI tool for testing REST APIs and services. Windows OS only.
 * [Http-console](https://github.com/cloudhead/http-console) - Command line interface for HTTP that let you *speak HTTP like a local*
+* [HTTP Prompt](https://github.com/eliangcs/http-prompt) - HTTP Prompt is an interactive command-line HTTP client featuring autocomplete and syntax highlighting, built on HTTPie and prompt_toolkit.
 * [rest-assured](https://github.com/rest-assured/rest-assured) - Java DSL for easy testing of REST services.
 * [Insomnia](https://github.com/getinsomnia/insomnia) - Cross-platform HTTP and GraphQL Client
 


### PR DESCRIPTION
Adding http-prompt. I'd suggest removing http-console, as it did not received commits for almost two years now. Features are similar.