### PR TITLE
Replace hurl.it by extendsclass.com in Querying section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 
 ### Querying
 
-* [Hurl.it](https://www.hurl.it/) - Make HTTP requests with a simple web-based HTTP client -- like `curl` in the cloud.
 * [httpie](https://github.com/jkbrzt/httpie) - Command line HTTP client, far more dev-friendly than `curl`.
 * [Postman REST Client](https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm) - Chrome extension essential to test manually REST API.
 * [resty](https://github.com/micha/resty) - Little command line REST client that you can use in pipelines (bash or zsh).
@@ -200,6 +199,8 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [HTTP Prompt](https://github.com/eliangcs/http-prompt) - HTTP Prompt is an interactive command-line HTTP client featuring autocomplete and syntax highlighting, built on HTTPie and prompt_toolkit.
 * [rest-assured](https://github.com/rest-assured/rest-assured) - Java DSL for easy testing of REST services.
 * [Insomnia](https://github.com/getinsomnia/insomnia) - Cross-platform HTTP and GraphQL Client
+* [ExtendsClass](https://extendsclass.com/rest-client-online.html) - Make HTTP requests with a simple web-based HTTP client.
+
 
 ### Mocking
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [Insomnia](https://github.com/getinsomnia/insomnia) - Cross-platform HTTP and GraphQL Client
 * [ExtendsClass](https://extendsclass.com/rest-client-online.html) - Make HTTP requests with a simple web-based HTTP client.
 
-
 ### Mocking
 
 * [RequestBin](https://requestbin.com/) - Inspect and debug webhook requests sent by your clients or third-party APIs.


### PR DESCRIPTION
Hurl.it does not exist anymore, this online rest client has been replaced by extendsclass.com in Querying section.