### PR TITLE
Add Mockintosh

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [Request Baskets](https://github.com/darklynx/request-baskets) - Service to collect HTTP requests and inspect them via RESTful API or web UI.
 * [DuckRails](https://github.com/iridakos/duckrails) - Mock quickly & dynamically API endpoints.
 * [Mockoon](https://mockoon.com) - Easily create mock APIs locally. No remote deployment, no account required, open source.
+* [Mockintosh](https://mockintosh.io/) - A mock server generator that's capable to generate RESTful APIs and communicate with the message queues to mimick asynchronous tasks.
 
 ### Public REST APIs To Use In Tests
 * [Deck of Cards API](http://deckofcardsapi.com) - Open API for simulating a deck of cards.


### PR DESCRIPTION
[Mockintosh](https://mockintosh.io/) is a mock server generator that's capable to generate RESTful APIs and communicate with the message queues to mimick asyncronous tasks.