### PR TITLE
Adding Dynaboard to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [swagger-codegen](https://github.com/swagger-api/swagger-codegen) - Auto generation of client libraries or server stubs given an OpenAPI specification (formerly known as the Swagger Specification).
 * [Lumber](https://github.com/ForestAdmin/lumber) - Generate the admin interface of your application.
 * [Linx](https://linx.software) - Low-code API platform. Build, debug and host REST APIs 
+* [Dynaboard](https://dynaboard.com) — Generate low-code web apps from any RESTful API using AI.
 
 
 ## License


### PR DESCRIPTION
Adding [Dynaboard](https://dynaboard.com/). It lets devs generate low-code web apps or admin interfaces on top of their RESTful APIs.