### PR TITLE
Add MockAPI-PHP to the list of Mocking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [DuckRails](https://github.com/iridakos/duckrails) - Mock quickly & dynamically API endpoints.
 * [Mockoon](https://mockoon.com) - Easily create mock APIs locally. No remote deployment, no account required, open source.
 * [Mockintosh](https://mockintosh.io/) - A mock server generator that's capable to generate RESTful APIs and communicate with the message queues to mimick asynchronous tasks.
+* [MockAPI-PHP](https://github.com/ka215/MockAPI-PHP) - Lightweight PHP-based mock API server with dynamic responses, polling, and OpenAPI 3.0 schema generation.
 
 ### Validating
 


### PR DESCRIPTION
This PR adds [MockAPI-PHP](https://github.com/ka215/MockAPI-PHP) to the list.

**MockAPI-PHP** is a lightweight, file-based mock API server written in PHP.  
It supports dynamic endpoints, polling, error simulation, and response delays — all configurable via `.json` or `.txt` files. Most notably, it can **automatically generate OpenAPI 3.0 schemas** from mock responses using a CLI or web interface.

✅ Features:
- Written in PHP 8.3+
- File-based mock responses (no framework required)
- Dynamic parameters, custom hooks, and logging
- Built-in OpenAPI 3.0 schema generator (YAML/JSON)
- Supports CI/CD and API-first development

GitHub: https://github.com/ka215/MockAPI-PHP
Article: https://dev.to/ka215/automatically-generate-openapi-30-schemas-from-mock-api-responses-using-php-1emi

Let me know if any changes are needed!