### PR TITLE
add JavaScript Client jin-frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fie
 * [restful.js](https://github.com/marmelab/restful.js) - JS client for interacting with server-side RESTful resources.
 * [traverson](https://github.com/basti1302/traverson) - A Hypermedia API/HATEOAS Client for Node.js and the Browser
 * [raml-client-generator](https://github.com/mulesoft/raml-client-generator) - Generates static client libs for js.
+* [jin-frame](https://github.com/imjuni/jin-frame) - Type-safe, declarative HTTP requests as reusable TypeScript classes.
 
 ### Node.js Clients
 


### PR DESCRIPTION
Hello, I would like to request adding **jin-frame** to the `### JavaScript Clients` section.

[jin-frame](https://github.com/imjuni/jin-frame) is a type-safe and declarative HTTP request client for **Browser** and **Node.js**, designed around reusable TypeScript classes. It provides strong typing, reusability, and a clear class-based API for managing HTTP requests.