### PR TITLE
Add CoinPulse - crypto portfolio REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 
 * [Public APIS](https://github.com/public-apis/public-apis) - Explore The Largest API Directory In The Galaxy.
 * [APIs.guru](https://APIs.guru) - Wikipedia for Web APIs, each API has OpenAPI/Swagger description.
-* [CoinPulse](https://coinpulse.dev) - Free REST API for cryptocurrency portfolio tracking with real-time prices and P/L calculations. Free tier: 25 req/hr.
+* [CoinPulse](https://coinpulse.fly.dev) - Free REST API for cryptocurrency portfolio tracking with real-time prices and P/L calculations. Free tier: 25 req/hr.
 * [JSON Placeholder](https://jsonplaceholder.typicode.com/) - Fake REST API abput posts, users and comments
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 
 * [Public APIS](https://github.com/public-apis/public-apis) - Explore The Largest API Directory In The Galaxy.
 * [APIs.guru](https://APIs.guru) - Wikipedia for Web APIs, each API has OpenAPI/Swagger description.
+* [CoinPulse](https://coinpulse.dev) - Free REST API for cryptocurrency portfolio tracking with real-time prices and P/L calculations. Free tier: 25 req/hr.
 * [JSON Placeholder](https://jsonplaceholder.typicode.com/) - Fake REST API abput posts, users and comments
 
 ## Documentation


### PR DESCRIPTION
## Add CoinPulse REST API

Hi! I'd like to add CoinPulse to the Public REST APIs section.

**What it is**: A free REST API for cryptocurrency portfolio tracking.

**Features**:
- Real-time prices for 15 cryptocurrencies
- Portfolio tracking with P/L calculations
- Historical price data
- Price alerts
- Free tier: 25 requests/hour (no credit card required)
- OpenAPI/Swagger docs included

**Links**:
- API: https://coinpulse.fly.dev
- Docs: https://coinpulse.fly.dev/docs
- Python SDK: `pip install coinpulse`

Great for testing and learning REST API patterns!

Thanks for maintaining this list!