### PR TITLE
Add Webhook Debugger to Mocking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 * [Mockoon](https://mockoon.com) - Easily create mock APIs locally. No remote deployment, no account required, open source.
 * [Mockintosh](https://mockintosh.io/) - A mock server generator that's capable to generate RESTful APIs and communicate with the message queues to mimick asynchronous tasks.
 * [Mockae](https://mockae.com/) - Fake REST API powered by Lua.
+* [Webhook Debugger](https://github.com/brancogao/webhook-debugger) - Open-source webhook debugging tool with 90-day request history and real-time inspection.
 
 ### Validating
 


### PR DESCRIPTION
## Summary
Added Webhook Debugger to the Mocking section under Testing category.

## Details
- **Webhook Debugger** - Open-source webhook debugging tool with 90-day request history and real-time inspection
- GitHub: https://github.com/brancogao/webhook-debugger
- Demo: https://webhook-debugger.autocompany.workers.dev

This tool fits well alongside other mocking/debugging tools like RequestBin, Request Baskets, and Mockoon.

## Checklist
- [x] The title is formatted according to the other entries
- [x] The entry is placed in the appropriate section