### PR TITLE
Add Spiderhash webhook debugging tool to Mocking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 
 ### Mocking
 
+* [Spiderhash](https://spiderhash.io/) - Webhook debugging and request inspection tool for capturing, replaying, and troubleshooting inbound webhook/API events in real time.
 * [FakeRest](https://github.com/marmelab/FakeRest) - Redirect fetch() calls to a client-side fake REST API.
 * [json-server](https://github.com/typicode/json-server) - Serve a REST API from fixture files using quick prototyping.
 * [RequestBin](https://requestbin.com/) - Inspect and debug webhook requests sent by your clients or third-party APIs.


### PR DESCRIPTION
## Summary
- add Spiderhash (https://spiderhash.io) to the Mocking section
- include concise description for webhook/API event debugging and request inspection

## Why
Spiderhash is relevant for REST/webhook testing workflows where teams need to inspect, replay, and troubleshoot incoming HTTP callbacks and API events.
