### PR TITLE
Add ProofBets free crypto casino REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 * [Public APIS](https://github.com/public-apis/public-apis) - Explore The Largest API Directory In The Galaxy.
 * [APIs.guru](https://APIs.guru) - Wikipedia for Web APIs, each API has OpenAPI/Swagger description.
 * [JSON Placeholder](https://jsonplaceholder.typicode.com/) - Fake REST API abput posts, users and comments
+* [ProofBets API](https://proofbets.com/developers/) - 16-endpoint REST API for crypto casino data with OpenAPI 3.1 spec, ETags, RFC 9457 errors, and rate limit headers. Free tier available.
 
 ## Documentation
 


### PR DESCRIPTION
ProofBets provides a free public REST API for crypto casino and prediction market data — a good real-world example of a well-structured REST API with OpenAPI 3.1, ETags, RFC 9457 Problem Details errors, and rate limiting.

- 16 endpoints at https://proofbets.com/api/v1/
- OpenAPI spec: https://proofbets.com/openapi.yaml
- Free tier: no API key required, 20 req/min
- Features: ETags + 304, Cache-Control, X-RateLimit headers, RFC 9457 errors

Added to the 'Public REST APIs To Use In Tests' section.