### PR TITLE
Add CoinPaprika to Public REST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 
 * [Public APIs](https://publicapis.dev/) - The world's largest directory of public APIs.
 * [APIs.guru](https://APIs.guru) - Wikipedia for Web APIs, each API has OpenAPI/Swagger description.
+* [CoinPaprika](https://api.coinpaprika.com) - Free cryptocurrency market data REST API with 7,000+ coins, tickers, exchanges, and OHLCV. No authentication required.
 * [JSON Placeholder](https://jsonplaceholder.typicode.com/) - Fake REST API abput posts, users and comments
 
 ## Documentation


### PR DESCRIPTION
Adds CoinPaprika to the "Public REST APIs To Use In Tests" section.

Plain REST, JSON, no auth header: 12,000+ coins, 350+ exchanges, tickers and OHLCV. The no-key part is what makes it useful for the purpose of this section, since a test or a demo can hit it without a signup step.

The free tier is metered. Current limits: https://coinpaprika.com/api/pricing
