### PR TITLE
Add spec2cli to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 ### Generators
 
 * [openapi-generator](https://github.com/OpenAPITools/openapi-generator) - OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3).
+* [spec2cli](https://github.com/lucianfialho/spec2cli) - Turn any OpenAPI/Swagger spec into a CLI at runtime — no code generation, no build step.
 
 ## Servers
 


### PR DESCRIPTION
[spec2cli](https://github.com/lucianfialho/spec2cli) — Turn any OpenAPI/Swagger spec into a CLI at runtime. No code generation, no build step.

Unlike openapi-generator which generates source code, spec2cli reads the spec at runtime and dynamically builds CLI commands with flags, auth, and formatted output.

Published on npm: https://www.npmjs.com/package/spec2cli