### PR TITLE
Add SnapAPI to Public REST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 * [Public APIs](https://publicapis.dev/) - The world's largest directory of public APIs.
 * [APIs.guru](https://APIs.guru) - Wikipedia for Web APIs, each API has OpenAPI/Swagger description.
 * [JSON Placeholder](https://jsonplaceholder.typicode.com/) - Fake REST API abput posts, users and comments
+* [SnapAPI](https://api-snap.com) - Bundled utility APIs (QR codes, screenshots, PDFs, email validation, IP geolocation, and more) with a single REST endpoint and API key.
 
 ## Documentation
 


### PR DESCRIPTION
Added SnapAPI to the "Public REST APIs To Use In Tests" section.

**SnapAPI** (https://api-snap.com) provides 13+ utility APIs through a single REST endpoint — QR codes, screenshots, HTML-to-PDF, email validation, IP geolocation, URL shortening, image resizing, hashing, UUID generation, base64 encoding, and more. It ships with an OpenAPI spec (https://api-snap.com/openapi.json) and offers a free tier, making it useful for testing REST client libraries and API tooling.