### PR TITLE
Fix httsp:// typo in CC license badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,6 @@ A collaborative list of great resources about RESTful API architecture, developm
 
 ## License
 
-[![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](httsp://creativecommons.org/licenses/by/4.0/)
+[![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](https://creativecommons.org/licenses/by/4.0/)
 
 This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Line 317 of README.md has `httsp://creativecommons.org/licenses/by/4.0/` (transposed letters) as the link target for the Creative Commons license badge. The duplicate plain-text link two lines below uses the correct `https://creativecommons.org/licenses/by/4.0/`, so this is a localized typo.