### PR TITLE
Add har2sdk to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 ### Generators
 
 * [openapi-generator](https://github.com/OpenAPITools/openapi-generator) - OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3).
+* [har2sdk](https://har2sdk.vercel.app/) - Paste a browser HAR (Chrome / Firefox network export) and generate a typed TypeScript fetch SDK with semantic method names, resource grouping, and auth detection. No OpenAPI spec required.
 
 ## Servers
 


### PR DESCRIPTION
Adds [har2sdk](https://har2sdk.vercel.app/) to the `Clients → Generators` section.

har2sdk takes a browser HAR file (recorded via DevTools → Network → Save all as HAR) and emits a typed TypeScript fetch SDK with semantic method names, resource grouping, and auth detection — covering the common case where a third-party or internal API has no published OpenAPI spec. Complementary to openapi-generator (which requires a spec); har2sdk skips the OpenAPI intermediate entirely.

- Live URL: https://har2sdk.vercel.app/
- Source: https://github.com/SolvoHQ/har2sdk
- Free, no signup. Built on Astro + Vercel + Anthropic Haiku 4.5.