### PR TITLE
Add Sourcey to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ A collaborative list of great resources about RESTful API architecture, developm
 * [Slate](https://github.com/lord/slate) - Beautiful and responsive three-panel API documentation using Middleman.
 * [Optic](https://github.com/opticdev/optic) - Maintain an accurate API specification without writing OpenAPI/Swagger. Works with any Stack
 * [Zudoku](https://zudoku.dev/) - Create clean, consistent API docs with Zudoku — open source, extensible, and developer-first
+* [Sourcey](https://sourcey.com/) - Static documentation generator from OpenAPI, MCP, Doxygen, godoc, and Markdown sources.
 
 ## API Gateway
 


### PR DESCRIPTION
Sourcey (https://sourcey.com) is an open-source static documentation generator that handles OpenAPI natively alongside MCP server manifests, Doxygen XML, godoc, and Markdown sources. Output is plain static HTML with no runtime, deployable anywhere.

Fits the Documentation section alongside ReDoc, Slate, and Zudoku as another OSS option that consumes OpenAPI.

- Project: https://sourcey.com
- Live demo: https://sourcey.com/cheesestore
- Source: https://github.com/sourcey/sourcey
- License: AGPL-3.0